### PR TITLE
Updated Eval Pipeline

### DIFF
--- a/datasetinsights/cli.py
+++ b/datasetinsights/cli.py
@@ -179,8 +179,9 @@ def run(command, cfg):
     # todo this makes it so that we lose the tensorboard writer of non-master
     # processes which could make debugging harder
     writer = SummaryWriter(logdir, write_to_disk=is_master())
-    kfp_writer = KubeflowPipelineWriter(filename=cfg.system.metricsfilename,
-                                        filepath=cfg.system.metricsdir)
+    kfp_writer = KubeflowPipelineWriter(
+        filename=cfg.system.metricsfilename, filepath=cfg.system.metricsdir
+    )
     checkpointer = create_checkpointer(logdir=writer.logdir, config=cfg)
     estimator = Estimator.create(
         cfg.estimator,

--- a/datasetinsights/storage/kfp_output.py
+++ b/datasetinsights/storage/kfp_output.py
@@ -64,3 +64,9 @@ class KubeflowPipelineWriter(object):
             os.makedirs(self.filepath)
         with open(os.path.join(self.filepath, self.filename), "w") as f:
             json.dump(self.data, f)
+
+        logger.debug(
+            "Metrics file {0} saved at path: {1}".format(
+                self.filename, self.filepath
+            )
+        )

--- a/kubeflow/evaluate_pipeline.py
+++ b/kubeflow/evaluate_pipeline.py
@@ -30,6 +30,7 @@ def evaluate_pipeline(
             "datasetinsights.cli",
             "evaluate",
             "--verbose",
+            "--metricsdir=/",
             "--config=datasetinsights/configs/faster_rcnn_synthetic.yaml",
             f"--logdir={logdir}",
             f"checkpoint_file",
@@ -37,6 +38,7 @@ def evaluate_pipeline(
             f"test.dataset.args.split",
             test_split,
         ],
+        file_outputs={"mlpipeline-metrics": "/mlpipeline-metrics.json"},
     )
     # GPU limit here has to be hard coded integer instead of derived from
     # num_proc, otherwise it will fail kubeflow validation as it will create


### PR DESCRIPTION
# Peer Review Information

Updated evaluation pipeline to use `metricsdir` argument to provide path to save metrics json file.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Please read our [contribution guide](https://github.com/Unity-Technologies/dataset-insights/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [x] Tested [**kubeflow run**](https://datasetinsights.endpoints.unity-ai-thea-test.cloud.goog/_/pipeline/#/runs/new?cloneFromRun=74e0ec9f-cf0b-4b18-b3ae-40ae53a8563b) for changed code.
