### PR TITLE
ignore mock data and do isort for all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-        exclude: ^mock_data/
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
+        exclude: ^mock_data/
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: check-merge-conflict

--- a/datasetinsights/data/simulation/download.py
+++ b/datasetinsights/data/simulation/download.py
@@ -12,9 +12,9 @@ from requests.packages.urllib3.util.retry import Retry
 from tqdm import tqdm
 
 import datasetinsights.constants as const
-
 from datasetinsights.data.download import TimeoutHTTPAdapter, download_file
 from datasetinsights.data.exceptions import DownloadError
+
 from .tables import DATASET_TABLES, FileType
 
 logger = logging.getLogger(__name__)

--- a/tests/simulation/test_download.py
+++ b/tests/simulation/test_download.py
@@ -54,13 +54,17 @@ def test_download_bad_request():
 
 def test_download_rows(downloader):
     n_rows = len(downloader.manifest)
-    with patch("datasetinsights.data.download.download_file") as mocked_dl:
+    with patch(
+        "datasetinsights.data.simulation.download.download_file"
+    ) as mocked_dl:
         matched_rows = pd.Series(np.zeros(n_rows).astype(bool))
         downloaded = downloader._download_rows(matched_rows)
         assert len(downloaded) == 0
         mocked_dl.assert_not_called()
 
-    with patch("datasetinsights.data.download.download_file") as mocked_dl:
+    with patch(
+        "datasetinsights.data.simulation.download.download_file"
+    ) as mocked_dl:
         matched_rows = pd.Series(np.ones(n_rows).astype(bool))
         downloaded = downloader._download_rows(matched_rows)
         assert len(downloaded) == n_rows
@@ -69,7 +73,9 @@ def test_download_rows(downloader):
 
 def test_download_all(downloader):
     n_rows = len(downloader.manifest)
-    with patch("datasetinsights.data.download.download_file") as mocked_dl:
+    with patch(
+        "datasetinsights.data.simulation.download.download_file"
+    ) as mocked_dl:
         downloader.download_references()
         downloader.download_captures()
         downloader.download_metrics()


### PR DESCRIPTION
# Peer Review Information

do isort in the current master and ignore `mock_data` folder when doing `end-of-file-fixer` check. 
