### PR TITLE
Update public GroceriesReal path in datasetinsights

### DIFF
--- a/datasetinsights/data/datasets/groceries_real.py
+++ b/datasetinsights/data/datasets/groceries_real.py
@@ -21,7 +21,7 @@ from .protos import string_int_label_map_pb2
 
 logger = logging.getLogger(__name__)
 PUBLIC_GROCERIES_REAL_PATH = (
-    "https://storage.googleapis.com/datasetinsights_public/data/groceries"
+    "https://storage.googleapis.com/datasetinsights/data/groceries"
 )
 GroceriesRealTable = namedtuple(
     "GroceriesRealTable", ("version", "filename", "source_uri", "checksum")


### PR DESCRIPTION
# Peer Review Information

Since we move all public data and model in a new GCS bucket, named "datasetinsights". Update public GroceriesReal path in datasetinsights.