### PR TITLE
[Fix] Estimator Call to KFP Writer

### DIFF
--- a/datasetinsights/estimators/base.py
+++ b/datasetinsights/estimators/base.py
@@ -37,7 +37,7 @@ def create_estimator(
 
     writer = SummaryWriter(tb_log_dir)
     kfp_writer = KubeflowPipelineWriter(
-        filename=kfp_metrics_dir, filepath=kfp_metrics_filename,
+        filename=kfp_metrics_filename, filepath=kfp_metrics_dir,
     )
     checkpointer = EstimatorCheckpoint(
         estimator_name=name, checkpoint_dir=checkpoint_dir, distributed=False,

--- a/datasetinsights/io/download.py
+++ b/datasetinsights/io/download.py
@@ -40,7 +40,7 @@ def download_file(source_uri: str, dest_path: str, file_name: str = None):
     Returns:
         String of destination path.
     """
-    logger.debug(f"Trying to download file from {source_uri} -> {dest_path}")
+    logger.info(f"Trying to download file from {source_uri} -> {dest_path}")
     adapter = TimeoutHTTPAdapter(
         timeout=DEFAULT_TIMEOUT, max_retries=Retry(total=DEFAULT_MAX_RETRIES)
     )

--- a/tests/test_kfp_output.py
+++ b/tests/test_kfp_output.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from datasetinsights.io.kfp_output import KubeflowPipelineWriter
 
@@ -13,17 +14,20 @@ def test_kfp_writer_save_and_overwrite_metric():
 
 
 def test_serialize_and_write_metrics():
-    file_name = "metrics.json"
-    file_path = os.path.dirname(os.getcwd())
-    expected_data = {
-        "metrics": [
-            {"name": "mAR", "numberValue": 0.787, "format": "RAW"},
-            {"name": "mAP", "numberValue": 0.667, "format": "RAW"},
-        ]
-    }
-    writer_obj = KubeflowPipelineWriter(filename=file_name, filepath=file_path)
-    writer_obj.add_metric(name="mAR", val=0.787)
-    writer_obj.add_metric(name="mAP", val=0.667)
-    writer_obj.write_metric()
-    assert writer_obj.data == expected_data
-    assert os.path.exists(os.path.join(file_name, file_path))
+    with tempfile.TemporaryDirectory() as tmp:
+        file_name = "metrics.json"
+        file_path = tmp
+        expected_data = {
+            "metrics": [
+                {"name": "mAR", "numberValue": 0.787, "format": "RAW"},
+                {"name": "mAP", "numberValue": 0.667, "format": "RAW"},
+            ]
+        }
+        writer_obj = KubeflowPipelineWriter(
+            filename=file_name, filepath=file_path
+        )
+        writer_obj.add_metric(name="mAR", val=0.787)
+        writer_obj.add_metric(name="mAP", val=0.667)
+        writer_obj.write_metric()
+        assert writer_obj.data == expected_data
+        assert os.path.exists(os.path.join(file_name, file_path))


### PR DESCRIPTION
# Peer Review Information

Estimator call to kfp writer was passing `filename` and `filepath` incorrectly.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Please read our [contribution guide](https://github.com/Unity-Technologies/dataset-insights/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
