### PR TITLE
Low hdd and memory size are causing large synthetic datasets to fail.

### DIFF
--- a/kubeflow/compiled/train_on_synthetic_dataset_unity_simulation.yaml
+++ b/kubeflow/compiled/train_on_synthetic_dataset_unity_simulation.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-synthetic-dataset-unity-simulation-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.0, pipelines.kubeflow.org/pipeline_compilation_time: '2020-08-28T22:40:58.228098',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.0, pipelines.kubeflow.org/pipeline_compilation_time: '2020-09-16T08:32:22.944114',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on synthetic dataset
       Unity Simulation", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "<unity-project-id>",
@@ -12,7 +12,7 @@ metadata:
       "type": "String"}, {"default": "datasetinsights/configs/faster_rcnn_synthetic.yaml",
       "name": "config", "optional": true, "type": "String"}, {"default": "gs://<bucket>/runs/yyyymmdd-hhmm",
       "name": "tb_log_dir", "optional": true, "type": "String"}, {"default": "gs://<bucket>/checkpoints/yyyymmdd-hhmm",
-      "name": "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
+      "name": "checkpoint_dir", "optional": true, "type": "String"}, {"default": "1.5Ti",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on synthetic dataset Unity Simulation"}'}
   labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.0}
@@ -29,8 +29,8 @@ spec:
       - {name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, value: /secret/gcp-credentials/user-gcp-sa.json}
       image: '{{inputs.parameters.docker}}'
       resources:
-        limits: {memory: 64Gi}
-        requests: {memory: 64Gi}
+        limits: {memory: 256Gi}
+        requests: {memory: 256Gi}
       volumeMounts:
       - {mountPath: /data, name: pvc}
       - {mountPath: /secret/gcp-credentials, name: gcp-credentials-user-gcp-sa}
@@ -82,8 +82,8 @@ spec:
       - {name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, value: /secret/gcp-credentials/user-gcp-sa.json}
       image: '{{inputs.parameters.docker}}'
       resources:
-        limits: {nvidia.com/gpu: 8, memory: 64Gi}
-        requests: {memory: 64Gi}
+        limits: {nvidia.com/gpu: 8, memory: 256Gi}
+        requests: {memory: 256Gi}
       volumeMounts:
       - {mountPath: /data, name: pvc}
       - {mountPath: /secret/gcp-credentials, name: gcp-credentials-user-gcp-sa}
@@ -147,5 +147,5 @@ spec:
     - {name: config, value: datasetinsights/configs/faster_rcnn_synthetic.yaml}
     - {name: tb_log_dir, value: 'gs://<bucket>/runs/yyyymmdd-hhmm'}
     - {name: checkpoint_dir, value: 'gs://<bucket>/checkpoints/yyyymmdd-hhmm'}
-    - {name: volume_size, value: 100Gi}
+    - {name: volume_size, value: 1.5Ti}
   serviceAccountName: pipeline-runner

--- a/kubeflow/pipelines.py
+++ b/kubeflow/pipelines.py
@@ -400,14 +400,14 @@ def train_on_synthetic_dataset_unity_simulation(
     config: str = "datasetinsights/configs/faster_rcnn_synthetic.yaml",
     tb_log_dir: str = "gs://<bucket>/runs/yyyymmdd-hhmm",
     checkpoint_dir: str = "gs://<bucket>/checkpoints/yyyymmdd-hhmm",
-    volume_size: str = "100Gi",
+    volume_size: str = "1.5Ti",
 ):
     output = train_data = val_data = DATA_PATH
 
     # The following parameters can't be `PipelineParam` due to this issue:
     # https://github.com/kubeflow/pipelines/issues/1956
     # Instead, they have to be configured when the pipeline is compiled.
-    memory_limit = "64Gi"
+    memory_limit = "256Gi"
     num_gpu = 8
     gpu_type = "nvidia-tesla-v100"
 


### PR DESCRIPTION
# Peer Review Information
Low hdd and memory size are causing large synthetic datasets to fail. Upping memory and hdd sizes to accomidate.

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Please read our [contribution guide](https://github.com/Unity-Technologies/dataset-insights/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
