### PR TITLE
Force no-cuda for faster rcnn tests

### DIFF
--- a/tests/test_faster_rcnn.py
+++ b/tests/test_faster_rcnn.py
@@ -63,6 +63,7 @@ def test_faster_rcnn_train_one_epoch(config, dataset):
         checkpointer=checkpointer,
         kfp_writer=kfp_writer,
         logdir="/tmp",
+        no_cuda=True,
     )
     estimator.writer = writer
     estimator.kfp_writer = kfp_writer
@@ -220,6 +221,7 @@ def test_faster_rcnn_evaluate_per_epoch(mock_loss, config, dataset):
         checkpointer=checkpointer,
         kfp_writer=kfp_writer,
         logdir="/tmp",
+        no_cuda=True,
     )
     estimator.writer = writer
     estimator.kfp_writer = kfp_writer
@@ -497,6 +499,7 @@ def test_faster_rcnn_predict(config, dataset):
         kfp_writer=kfp_writer,
         checkpoint_file=checkpoint_file,
         logdir="/tmp",
+        no_cuda=True,
     )
     estimator.writer = writer
     estimator.kfp_writer = kfp_writer


### PR DESCRIPTION
# Peer Review Information

This PR fixes a few unittests that will fail on CUDA enabled device. This change forces estimator initialized with `no_cuda` flag. 

```
tests/test_faster_rcnn.py:509:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
datasetinsights/estimators/faster_rcnn.py:512: in predict
    predicts = self.model_without_ddp(img_tensor)
../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torch/nn/modules/module.py:532: in __call__
    result = self.forward(*input, **kwargs)
../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torchvision/models/detection/generalized_rcnn.py:67: in forward
    features = self.backbone(images.tensors)
../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torch/nn/modules/module.py:532: in __call__
    result = self.forward(*input, **kwargs)
../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torchvision/models/detection/backbone_utils.py:39: in forward
    x = self.body(x)
../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torch/nn/modules/module.py:532: in __call__
    result = self.forward(*input, **kwargs)
../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torchvision/models/_utils.py:63: in forward
    x = module(x)
../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torch/nn/modules/module.py:532: in __call__
    result = self.forward(*input, **kwargs)
../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torch/nn/modules/conv.py:345: in forward
    return self.conv2d_forward(input, self.weight)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = Conv2d(3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)
input = tensor([[[[ 1.7523,  1.7523,  1.0690,  ..., -0.1657, -1.0390, -1.0390],
          [ 1.7523,  1.7523,  1.0690,  ..., -0..., -0.1347,  ...,  0.0988, -0.7064, -0.7064],
          [ 0.5136,  0.5136, -0.1347,  ...,  0.0988, -0.7064, -0.7064]]]])
weight = Parameter containing:
tensor([[[[ 1.3335e-02,  1.4664e-02, -1.5351e-02,  ..., -4.0896e-02,
           -4.3034e-02, -7....   [ 1.0456e-02,  1.9020e-02, -1.5351e-02,  ..., -1.1350e-01,
            6.7615e-02, -6.7650e-03]]]], device='cuda:0')

    def conv2d_forward(self, input, weight):
        if self.padding_mode == 'circular':
            expanded_padding = ((self.padding[1] + 1) // 2, self.padding[1] // 2,
                                (self.padding[0] + 1) // 2, self.padding[0] // 2)
            return F.conv2d(F.pad(input, expanded_padding, mode='circular'),
                            weight, self.bias, self.stride,
                            _pair(0), self.dilation, self.groups)
        return F.conv2d(input, weight, self.bias, self.stride,
>                       self.padding, self.dilation, self.groups)
E       RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same

../../miniconda3/envs/dins-dev/lib/python3.7/site-packages/torch/nn/modules/conv.py:342: RuntimeError
```

# Pull Request Check List

- [x] Updated **tests**
