### PR TITLE
Github Actions Update

### DIFF
--- a/.github/workflows/linting-and-unittests.yaml
+++ b/.github/workflows/linting-and-unittests.yaml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
         run: |
           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-          echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Configure poetry
         shell: bash
         run: poetry config virtualenvs.in-project true

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -27,9 +27,9 @@ jobs:
         shell: bash
         run: |
           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-          echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Set env
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name : Configure poetry
         shell: bash
         run: poetry config pypi-token.pypi $PYPI_TOKEN


### PR DESCRIPTION
# Peer Review Information

The `set-env` and `add-path` command is deprecated and will be disabled soon. Link: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
