### PR TITLE
Remove running loss in Faster RCNN model training

### DIFF
--- a/datasetinsights/estimators/faster_rcnn.py
+++ b/datasetinsights/estimators/faster_rcnn.py
@@ -318,11 +318,6 @@ class FasterRCNN(Estimator):
                 optimizer.zero_grad()
         self.writer.add_scalar("training/loss", loss_metric.compute(), epoch)
         self.writer.add_scalar(
-            "training/running_loss",
-            loss_metric.compute(),
-            loss_metric.num_examples,
-        )
-        self.writer.add_scalar(
             "training/lr", optimizer.param_groups[0]["lr"], epoch
         )
         loss_metric.reset()


### PR DESCRIPTION
# Peer Review Information

This loss in tensorboard does not provide any meaningful result. It was replaced by `training/intermediate_loss`

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Please read our [contribution guide](https://github.com/Unity-Technologies/dataset-insights/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
