### PR TITLE
KFP Visualizer and SummaryWriter Fix

### DIFF
--- a/datasetinsights/commands/evaluate.py
+++ b/datasetinsights/commands/evaluate.py
@@ -57,16 +57,23 @@ logger = logging.getLogger(__name__)
     ),
 )
 @click.option(
-    "--kfp-metrics-dir",
+    "--kfp-log-dir",
     type=click.Path(file_okay=False, writable=True),
-    default=const.DEFAULT_KFP_METRICS_DIR,
-    help="Path to the directory where Kubeflow Metrics files are stored.",
+    default=const.DEFAULT_KFP_LOG_DIR,
+    help="Path to the directory where Kubeflow ui metadata file and "
+    "metrics are stored.",
 )
 @click.option(
     "--kfp-metrics-filename",
     type=click.STRING,
     default=const.DEFAULT_KFP_METRICS_FILENAME,
     help="Kubeflow Metrics filename.",
+)
+@click.option(
+    "--kfp-ui-metadata-filename",
+    type=click.STRING,
+    default=const.DEFAULT_KFP_UI_METADATA_FILENAME,
+    help="Kubeflow UI Metadata JSON filename (for tensorboard).",
 )
 @click.option(
     "--no-cuda",
@@ -83,8 +90,9 @@ def cli(
     test_data,
     tb_log_dir,
     workers,
-    kfp_metrics_dir,
+    kfp_log_dir,
     kfp_metrics_filename,
+    kfp_ui_metadata_filename,
     no_cuda,
 ):
     ctx = click.get_current_context()
@@ -97,8 +105,9 @@ def cli(
         checkpoint_file=checkpoint_file,
         tb_log_dir=tb_log_dir,
         workers=workers,
-        kfp_metrics_dir=kfp_metrics_dir,
+        kfp_log_dir=kfp_log_dir,
         kfp_metrics_filename=kfp_metrics_filename,
+        kfp_ui_metadata_filename=kfp_ui_metadata_filename,
         no_cuda=no_cuda,
     )
 

--- a/datasetinsights/commands/train.py
+++ b/datasetinsights/commands/train.py
@@ -56,6 +56,19 @@ logger = logging.getLogger(__name__)
     ),
 )
 @click.option(
+    "--kfp-log-dir",
+    type=click.Path(file_okay=False, writable=True),
+    default=const.DEFAULT_KFP_LOG_DIR,
+    help="Path to the directory where Kubeflow ui metadata file and "
+    "metrics are stored.",
+)
+@click.option(
+    "--kfp-ui-metadata-filename",
+    type=click.STRING,
+    default=const.DEFAULT_KFP_UI_METADATA_FILENAME,
+    help="Kubeflow UI Metadata JSON filename (for tensorboard).",
+)
+@click.option(
     "-p",
     "--checkpoint-dir",
     type=click.STRING,
@@ -98,6 +111,8 @@ def cli(
     val_data,
     checkpoint_file,
     tb_log_dir,
+    kfp_log_dir,
+    kfp_ui_metadata_filename,
     checkpoint_dir,
     workers,
     no_cuda,
@@ -114,6 +129,8 @@ def cli(
         config=config,
         checkpoint_file=checkpoint_file,
         tb_log_dir=tb_log_dir,
+        kfp_log_dir=kfp_log_dir,
+        kfp_ui_metadata_filename=kfp_ui_metadata_filename,
         checkpoint_dir=checkpoint_dir,
         no_cuda=no_cuda,
         no_val=no_val,

--- a/datasetinsights/constants.py
+++ b/datasetinsights/constants.py
@@ -5,10 +5,9 @@ TIMESTAMP_SUFFIX = datetime.now().strftime("%Y%m%d-%H%M%S")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
 
 # Default for tensorboard logs, checkpoints and metrics
-DEFAULT_KFP_METRICS_DIR = os.path.join(
-    PROJECT_ROOT, "metrics", TIMESTAMP_SUFFIX
-)
+DEFAULT_KFP_LOG_DIR = os.path.join(PROJECT_ROOT, "kfp", TIMESTAMP_SUFFIX)
 DEFAULT_KFP_METRICS_FILENAME = "mlpipeline-metrics.json"
+DEFAULT_KFP_UI_METADATA_FILENAME = "mlpipeline-ui-metadata.json"
 
 DEFAULT_TENSORBOARD_LOG_DIR = os.path.join(
     PROJECT_ROOT, "runs", TIMESTAMP_SUFFIX

--- a/datasetinsights/estimators/base.py
+++ b/datasetinsights/estimators/base.py
@@ -1,7 +1,5 @@
 from abc import ABCMeta, abstractmethod
 
-from torch.utils.tensorboard import SummaryWriter
-
 import datasetinsights.constants as const
 from datasetinsights.io.checkpoint import EstimatorCheckpoint
 from datasetinsights.io.kfp_output import KubeflowPipelineWriter
@@ -36,8 +34,6 @@ def create_estimator(
     # todo this makes it so that we lose the tensorboard
     #  writer of non-master processes which could make debugging harder
 
-    writer = SummaryWriter(log_dir=tb_log_dir)
-
     kfp_writer = KubeflowPipelineWriter(
         tb_log_dir=tb_log_dir,
         kfp_log_dir=kfp_log_dir,
@@ -53,7 +49,6 @@ def create_estimator(
         kfp_writer=kfp_writer,
         checkpointer=checkpointer,
         logdir=tb_log_dir,
-        writer=writer,
         no_cuda=no_cuda,
         no_val=no_val,
         **kwargs,

--- a/datasetinsights/estimators/faster_rcnn.py
+++ b/datasetinsights/estimators/faster_rcnn.py
@@ -19,7 +19,7 @@ import datasetinsights.constants as const
 from datasetinsights.datasets import Dataset
 from datasetinsights.evaluation_metrics.base import EvaluationMetric
 from datasetinsights.io.bbox import BBox2D
-from datasetinsights.io.summarywriter import DummySummaryWriter
+from datasetinsights.io.summarywriter import get_summary_writer
 from datasetinsights.io.transforms import Compose
 from datasetinsights.torch_distributed import get_world_size, is_master
 
@@ -63,7 +63,7 @@ class FasterRCNN(Estimator):
         self,
         *,
         config,
-        writer,
+        logdir,
         kfp_writer,
         checkpointer,
         box_score_thresh=0.05,
@@ -80,11 +80,8 @@ class FasterRCNN(Estimator):
         self.no_cuda = no_cuda
         self._init_device()
 
-        if is_master():
-            self.writer = writer
-        else:
-            logger.info("Dummy Summary Writer being used.")
-            self.writer = DummySummaryWriter()
+        summary_writer = get_summary_writer()
+        self.writer = summary_writer(logdir)
 
         self.kfp_writer = kfp_writer
         checkpointer.distributed = self.distributed

--- a/datasetinsights/estimators/faster_rcnn.py
+++ b/datasetinsights/estimators/faster_rcnn.py
@@ -19,6 +19,7 @@ import datasetinsights.constants as const
 from datasetinsights.datasets import Dataset
 from datasetinsights.evaluation_metrics.base import EvaluationMetric
 from datasetinsights.io.bbox import BBox2D
+from datasetinsights.io.summarywriter import DummySummaryWriter
 from datasetinsights.io.transforms import Compose
 from datasetinsights.torch_distributed import get_world_size, is_master
 
@@ -78,7 +79,12 @@ class FasterRCNN(Estimator):
         self._init_distributed_mode()
         self.no_cuda = no_cuda
         self._init_device()
-        self.writer = writer
+
+        if is_master():
+            self.writer = writer
+        else:
+            logger.info("Dummy Summary Writer being used.")
+            self.writer = DummySummaryWriter()
 
         self.kfp_writer = kfp_writer
         checkpointer.distributed = self.distributed
@@ -305,24 +311,22 @@ class FasterRCNN(Estimator):
                     f"(total training examples: {examples_seen}) is "
                     f"{intermediate_loss}"
                 )
-                if is_master():
-                    self.writer.add_scalar(
-                        "training/intermediate_loss",
-                        intermediate_loss,
-                        examples_seen,
-                    )
+
+                self.writer.add_scalar(
+                    "training/intermediate_loss",
+                    intermediate_loss,
+                    examples_seen,
+                )
             losses_grad.backward()
             if (i + 1) % accumulation_steps == 0:
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad()
-        if is_master():
-            self.writer.add_scalar(
-                "training/loss", loss_metric.compute(), epoch
-            )
-            self.writer.add_scalar(
-                "training/lr", optimizer.param_groups[0]["lr"], epoch
-            )
+
+        self.writer.add_scalar("training/loss", loss_metric.compute(), epoch)
+        self.writer.add_scalar(
+            "training/lr", optimizer.param_groups[0]["lr"], epoch
+        )
         loss_metric.reset()
 
     def evaluate(self, test_data, **kwargs):
@@ -422,8 +426,8 @@ class FasterRCNN(Estimator):
         self.log_metric_val(label_mappings, epoch)
         val_loss = loss_metric.compute()
         logger.info(f"validation loss is {val_loss}")
-        if is_master():
-            self.writer.add_scalar("val/loss", val_loss, epoch)
+
+        self.writer.add_scalar("val/loss", val_loss, epoch)
 
         torch.set_num_threads(n_threads)
 
@@ -439,8 +443,7 @@ class FasterRCNN(Estimator):
             logger.debug(result)
             logger.info(f"metric {metric_name} has result: {result}")
             if metric.TYPE == "scalar":
-                if is_master():
-                    self.writer.add_scalar(f"val/{metric_name}", result, epoch)
+                self.writer.add_scalar(f"val/{metric_name}", result, epoch)
                 self.kfp_writer.add_metric(name=metric_name, val=result)
             # TODO (YC) This is hotfix to allow user map between label_id
             # to label_name during model evaluation. In ideal cases this mapping
@@ -452,16 +455,12 @@ class FasterRCNN(Estimator):
                     label_mappings.get(id, str(id)): value
                     for id, value in result.items()
                 }
-                if is_master():
-                    self.writer.add_scalars(
-                        f"val/{metric_name}-per-class", label_results, epoch
-                    )
-                    fig = metric_per_class_plot(
-                        metric_name, result, label_mappings
-                    )
-                    self.writer.add_figure(
-                        f"{metric_name}-per-class", fig, epoch
-                    )
+
+                self.writer.add_scalars(
+                    f"val/{metric_name}-per-class", label_results, epoch
+                )
+                fig = metric_per_class_plot(metric_name, result, label_mappings)
+                self.writer.add_figure(f"{metric_name}-per-class", fig, epoch)
 
     def save(self, path):
         """Serialize Estimator to path.

--- a/datasetinsights/estimators/faster_rcnn.py
+++ b/datasetinsights/estimators/faster_rcnn.py
@@ -12,7 +12,6 @@ import torch
 import torch.distributed as dist
 import torchvision
 from codetiming import Timer
-from torch.utils.tensorboard import SummaryWriter
 from torchvision import transforms
 from tqdm import tqdm
 
@@ -63,7 +62,7 @@ class FasterRCNN(Estimator):
         self,
         *,
         config,
-        logdir,
+        writer,
         kfp_writer,
         checkpointer,
         box_score_thresh=0.05,
@@ -79,7 +78,7 @@ class FasterRCNN(Estimator):
         self._init_distributed_mode()
         self.no_cuda = no_cuda
         self._init_device()
-        self.writer = SummaryWriter(logdir)
+        self.writer = writer
 
         self.kfp_writer = kfp_writer
         checkpointer.distributed = self.distributed

--- a/datasetinsights/io/summarywriter.py
+++ b/datasetinsights/io/summarywriter.py
@@ -1,0 +1,57 @@
+class DummySummaryWriter:
+    """A fake summary writer that writes nothing to the disk.
+    """
+
+    def add_event(self, event, step=None, walltime=None):
+        return
+
+    def add_summary(self, summary, global_step=None, walltime=None):
+        return
+
+    def add_graph(self, graph_profile, walltime=None):
+        return
+
+    def add_scalar(self, tag, scalar_value, global_step=None, walltime=None):
+        return
+
+    def add_scalars(
+        self, main_tag, tag_scalar_dict, global_step=None, walltime=None
+    ):
+        return
+
+    def add_histogram(
+        self,
+        tag,
+        values,
+        global_step=None,
+        bins="tensorflow",
+        walltime=None,
+        max_bins=None,
+    ):
+        return
+
+    def add_histogram_raw(
+        self,
+        tag,
+        min,
+        max,
+        num,
+        sum,
+        sum_squares,
+        bucket_limits,
+        bucket_counts,
+        global_step=None,
+        walltime=None,
+    ):
+        return
+
+    def add_figure(
+        self, tag, figure, global_step=None, close=True, walltime=None
+    ):
+        return
+
+    def flush(self):
+        return
+
+    def close(self):
+        return

--- a/datasetinsights/io/summarywriter.py
+++ b/datasetinsights/io/summarywriter.py
@@ -1,53 +1,42 @@
+from torch.utils.tensorboard import SummaryWriter
+
+from datasetinsights.torch_distributed import is_master
+
+
 class DummySummaryWriter:
-    """A fake summary writer that writes nothing to the disk.
+    """A fake summary writer that writes nothing to the disk. This writer is
+    used when the process is not master process so that no data is written
+    which can prevent overwriting real data. This writer mimics the
+    SummaryWriter module in pytorch library. To see more about pytorch
+    tensorbaord summary writer visit:
+    https://github.com/pytorch/pytorch/blob/master/torch/utils/tensorboard/writer.py#L150
     """
 
-    def add_event(self, event, step=None, walltime=None):
+    def __init__(self, log_dir, *args, **kwargs):
+        self.logdir = log_dir
+
+    def add_event(self, *args, **kwargs):
         return
 
-    def add_summary(self, summary, global_step=None, walltime=None):
+    def add_summary(self, *args, **kwargs):
         return
 
-    def add_graph(self, graph_profile, walltime=None):
+    def add_graph(self, *args, **kwargs):
         return
 
-    def add_scalar(self, tag, scalar_value, global_step=None, walltime=None):
+    def add_scalar(self, *args, **kwargs):
         return
 
-    def add_scalars(
-        self, main_tag, tag_scalar_dict, global_step=None, walltime=None
-    ):
+    def add_scalars(self, *args, **kwargs):
         return
 
-    def add_histogram(
-        self,
-        tag,
-        values,
-        global_step=None,
-        bins="tensorflow",
-        walltime=None,
-        max_bins=None,
-    ):
+    def add_histogram(self, *args, **kwargs):
         return
 
-    def add_histogram_raw(
-        self,
-        tag,
-        min,
-        max,
-        num,
-        sum,
-        sum_squares,
-        bucket_limits,
-        bucket_counts,
-        global_step=None,
-        walltime=None,
-    ):
+    def add_histogram_raw(self, *args, **kwargs):
         return
 
-    def add_figure(
-        self, tag, figure, global_step=None, close=True, walltime=None
-    ):
+    def add_figure(self, *args, **kwargs):
         return
 
     def flush(self):
@@ -55,3 +44,16 @@ class DummySummaryWriter:
 
     def close(self):
         return
+
+
+def get_summary_writer():
+    """
+    Returns summary writer for tensorboard according to the process (master/
+    non master)
+    """
+    if is_master():
+        writer = SummaryWriter
+    else:
+        writer = DummySummaryWriter
+
+    return writer

--- a/kubeflow/compiled/evaluate_the_model.yaml
+++ b/kubeflow/compiled/evaluate_the_model.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: evaluate-the-model-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-23T14:11:46.915351',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:46.239358',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Evaluate the model", "inputs":
       [{"default": "unitytechnologies/datasetinsights:latest", "name": "docker", "optional":
       true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -12,7 +12,7 @@ metadata:
       "gs://<bucket>/runs/yyyymmdd-hhmm", "name": "tb_log_dir", "optional": true,
       "type": "String"}, {"default": "100Gi", "name": "volume_size", "optional": true,
       "type": "String"}], "name": "Evaluate the model"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
 spec:
   entrypoint: evaluate-the-model
   templates:

--- a/kubeflow/compiled/evaluate_the_model.yaml
+++ b/kubeflow/compiled/evaluate_the_model.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: evaluate-the-model-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:46.239358',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:55.837308',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Evaluate the model", "inputs":
       [{"default": "unitytechnologies/datasetinsights:latest", "name": "docker", "optional":
       true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -12,7 +12,7 @@ metadata:
       "gs://<bucket>/runs/yyyymmdd-hhmm", "name": "tb_log_dir", "optional": true,
       "type": "String"}, {"default": "100Gi", "name": "volume_size", "optional": true,
       "type": "String"}], "name": "Evaluate the model"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
 spec:
   entrypoint: evaluate-the-model
   templates:
@@ -43,7 +43,8 @@ spec:
   - name: evaluate
     container:
       args: ['--config={{inputs.parameters.config}}', '--checkpoint-file={{inputs.parameters.checkpoint_file}}',
-        --test-data=/data, '--tb-log-dir={{inputs.parameters.tb_log_dir}}']
+        --test-data=/data, '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/kfp_logs,
+        --kfp-ui-metadata-filename=kfp_ui_metadata.json, --kfp-metrics-filename=kfp_metrics.json]
       command: [datasetinsights, evaluate]
       env:
       - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /secret/gcp-credentials/user-gcp-sa.json}
@@ -62,6 +63,10 @@ spec:
       - {name: docker}
       - {name: pvc-name}
       - {name: tb_log_dir}
+    outputs:
+      artifacts:
+      - {name: mlpipeline-metrics, path: /kfp_logs/kfp_metrics.json}
+      - {name: mlpipeline-ui-metadata, path: /kfp_logs/kfp_ui_metadata.json}
     nodeSelector: {cloud.google.com/gke-accelerator: nvidia-tesla-v100}
     volumes:
     - name: gcp-credentials-user-gcp-sa

--- a/kubeflow/compiled/train_on_real_world_dataset.yaml
+++ b/kubeflow/compiled/train_on_real_world_dataset.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-real-world-dataset-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:43.445685',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:53.753331',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on real world dataset",
       "inputs": [{"default": "unitytechnologies/datasetinsights:latest", "name": "docker",
       "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -12,7 +12,7 @@ metadata:
       "name": "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on real world dataset"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
 spec:
   entrypoint: train-on-real-world-dataset
   templates:
@@ -68,7 +68,8 @@ spec:
   - name: train
     container:
       args: ['--config={{inputs.parameters.config}}', --train-data=/data, --val-data=/data,
-        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
+        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/kfp_logs,
+        '--kfp-ui-metadata-filename=kfp_ui_metadata.json--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
       command: [datasetinsights, train]
       env:
       - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /secret/gcp-credentials/user-gcp-sa.json}
@@ -89,7 +90,7 @@ spec:
       - {name: tb_log_dir}
     outputs:
       artifacts:
-      - {name: mlpipeline-ui-metadata, path: /mlpipeline-ui-metadata.json}
+      - {name: mlpipeline-ui-metadata, path: /kfp_logs/kfp_ui_metadata.json}
     nodeSelector: {cloud.google.com/gke-accelerator: nvidia-tesla-v100}
     volumes:
     - name: gcp-credentials-user-gcp-sa

--- a/kubeflow/compiled/train_on_real_world_dataset.yaml
+++ b/kubeflow/compiled/train_on_real_world_dataset.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-real-world-dataset-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-23T14:11:44.179717',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:43.445685',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on real world dataset",
       "inputs": [{"default": "unitytechnologies/datasetinsights:latest", "name": "docker",
       "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -12,7 +12,7 @@ metadata:
       "name": "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on real world dataset"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
 spec:
   entrypoint: train-on-real-world-dataset
   templates:
@@ -68,7 +68,7 @@ spec:
   - name: train
     container:
       args: ['--config={{inputs.parameters.config}}', --train-data=/data, --val-data=/data,
-        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
+        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
       command: [datasetinsights, train]
       env:
       - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /secret/gcp-credentials/user-gcp-sa.json}

--- a/kubeflow/compiled/train_on_synthdet_sample.yaml
+++ b/kubeflow/compiled/train_on_synthdet_sample.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-the-synthdet-sample-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-23T14:11:43.399951',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:42.569864',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on the SynthDet
       sample", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/synthetic/SynthDet.zip",
@@ -12,7 +12,7 @@ metadata:
       "name": "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on the SynthDet sample"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
 spec:
   entrypoint: train-on-the-synthdet-sample
   templates:
@@ -68,7 +68,7 @@ spec:
   - name: train
     container:
       args: ['--config={{inputs.parameters.config}}', --train-data=/data, --val-data=/data,
-        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
+        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
       command: [python, -m, torch.distributed.launch, --nproc_per_node=8, --use_env,
         datasetinsights, train]
       env:

--- a/kubeflow/compiled/train_on_synthdet_sample.yaml
+++ b/kubeflow/compiled/train_on_synthdet_sample.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-the-synthdet-sample-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:42.569864',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:52.999713',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on the SynthDet
       sample", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/synthetic/SynthDet.zip",
@@ -12,7 +12,7 @@ metadata:
       "name": "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on the SynthDet sample"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
 spec:
   entrypoint: train-on-the-synthdet-sample
   templates:
@@ -68,7 +68,8 @@ spec:
   - name: train
     container:
       args: ['--config={{inputs.parameters.config}}', --train-data=/data, --val-data=/data,
-        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
+        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/kfp_logs,
+        '--kfp-ui-metadata-filename=kfp_ui_metadata.json--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
       command: [python, -m, torch.distributed.launch, --nproc_per_node=8, --use_env,
         datasetinsights, train]
       env:
@@ -90,7 +91,7 @@ spec:
       - {name: tb_log_dir}
     outputs:
       artifacts:
-      - {name: mlpipeline-ui-metadata, path: /mlpipeline-ui-metadata.json}
+      - {name: mlpipeline-ui-metadata, path: /kfp_logs/kfp_ui_metadata.json}
     nodeSelector: {cloud.google.com/gke-accelerator: nvidia-tesla-v100}
     volumes:
     - name: gcp-credentials-user-gcp-sa

--- a/kubeflow/compiled/train_on_synthetic_and_real_dataset.yaml
+++ b/kubeflow/compiled/train_on_synthetic_and_real_dataset.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-synthetic-real-world-dataset-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:44.360008',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:54.469730',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on Synthetic + Real
       World Dataset", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -14,7 +14,7 @@ metadata:
       "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on Synthetic + Real World Dataset"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
 spec:
   entrypoint: train-on-synthetic-real-world-dataset
   templates:
@@ -70,7 +70,8 @@ spec:
   - name: train
     container:
       args: ['--config={{inputs.parameters.config}}', --train-data=/data, --val-data=/data,
-        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}',
+        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/kfp_logs,
+        '--kfp-ui-metadata-filename=kfp_ui_metadata.json--checkpoint-dir={{inputs.parameters.checkpoint_dir}}',
         '--checkpoint-file={{inputs.parameters.checkpoint_file}}']
       command: [datasetinsights, train]
       env:
@@ -93,7 +94,7 @@ spec:
       - {name: tb_log_dir}
     outputs:
       artifacts:
-      - {name: mlpipeline-ui-metadata, path: /mlpipeline-ui-metadata.json}
+      - {name: mlpipeline-ui-metadata, path: /kfp_logs/kfp_ui_metadata.json}
     nodeSelector: {cloud.google.com/gke-accelerator: nvidia-tesla-v100}
     volumes:
     - name: gcp-credentials-user-gcp-sa

--- a/kubeflow/compiled/train_on_synthetic_and_real_dataset.yaml
+++ b/kubeflow/compiled/train_on_synthetic_and_real_dataset.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-synthetic-real-world-dataset-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-23T14:11:45.221602',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:44.360008',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on Synthetic + Real
       World Dataset", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -14,7 +14,7 @@ metadata:
       "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on Synthetic + Real World Dataset"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
 spec:
   entrypoint: train-on-synthetic-real-world-dataset
   templates:
@@ -70,7 +70,7 @@ spec:
   - name: train
     container:
       args: ['--config={{inputs.parameters.config}}', --train-data=/data, --val-data=/data,
-        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}',
+        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}',
         '--checkpoint-file={{inputs.parameters.checkpoint_file}}']
       command: [datasetinsights, train]
       env:

--- a/kubeflow/compiled/train_on_synthetic_dataset_unity_simulation.yaml
+++ b/kubeflow/compiled/train_on_synthetic_dataset_unity_simulation.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-synthetic-dataset-unity-simulation-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:45.319131',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:55.152591',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on synthetic dataset
       Unity Simulation", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "<unity-project-id>",
@@ -15,7 +15,7 @@ metadata:
       "name": "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on synthetic dataset Unity Simulation"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
 spec:
   entrypoint: train-on-synthetic-dataset-unity-simulation
   templates:
@@ -74,7 +74,8 @@ spec:
   - name: train
     container:
       args: ['--config={{inputs.parameters.config}}', --train-data=/data, --val-data=/data,
-        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
+        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/kfp_logs,
+        '--kfp-ui-metadata-filename=kfp_ui_metadata.json--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
       command: [python, -m, torch.distributed.launch, --nproc_per_node=8, --use_env,
         datasetinsights, train]
       env:
@@ -96,7 +97,7 @@ spec:
       - {name: tb_log_dir}
     outputs:
       artifacts:
-      - {name: mlpipeline-ui-metadata, path: /mlpipeline-ui-metadata.json}
+      - {name: mlpipeline-ui-metadata, path: /kfp_logs/kfp_ui_metadata.json}
     nodeSelector: {cloud.google.com/gke-accelerator: nvidia-tesla-v100}
     volumes:
     - name: gcp-credentials-user-gcp-sa

--- a/kubeflow/compiled/train_on_synthetic_dataset_unity_simulation.yaml
+++ b/kubeflow/compiled/train_on_synthetic_dataset_unity_simulation.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-synthetic-dataset-unity-simulation-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-23T14:11:46.165607',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4, pipelines.kubeflow.org/pipeline_compilation_time: '2020-10-29T12:45:45.319131',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on synthetic dataset
       Unity Simulation", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "<unity-project-id>",
@@ -15,7 +15,7 @@ metadata:
       "name": "checkpoint_dir", "optional": true, "type": "String"}, {"default": "100Gi",
       "name": "volume_size", "optional": true, "type": "String"}], "name": "Train
       on synthetic dataset Unity Simulation"}'}
-  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1}
+  labels: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.4}
 spec:
   entrypoint: train-on-synthetic-dataset-unity-simulation
   templates:
@@ -74,7 +74,7 @@ spec:
   - name: train
     container:
       args: ['--config={{inputs.parameters.config}}', --train-data=/data, --val-data=/data,
-        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
+        '--tb-log-dir={{inputs.parameters.tb_log_dir}}', --kfp-log-dir=/, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
       command: [python, -m, torch.distributed.launch, --nproc_per_node=8, --use_env,
         datasetinsights, train]
       env:

--- a/kubeflow/pipelines.py
+++ b/kubeflow/pipelines.py
@@ -74,6 +74,7 @@ def train_op(
     num_gpu,
     gpu_type,
     checkpoint_file=None,
+    kfp_log_dir="/",
 ):
     """ Create a Kubeflow ContainerOp to train an estimator.
 
@@ -85,6 +86,8 @@ def train_op(
         checkpoint_file (str): Path to an estimator checkpoint file.
             If specified, model will resume from previous checkpoints.
         tb_log_dir (str): Path to tensorboard log directory.
+        kfp_log_dir (str): Directory where Kubeflow ui metadata file and
+            metrics are stored
         checkpoint_dir (str): Path to checkpoint file directory.
         volume (kfp.dsl.PipelineVolume): The volume where datasets are stored.
         memory_limit (str): Set memory limit for this operator. For simplicity,
@@ -114,6 +117,7 @@ def train_op(
         f"--train-data={train_data}",
         f"--val-data={val_data}",
         f"--tb-log-dir={tb_log_dir}",
+        f"--kfp-log-dir={kfp_log_dir}",
         f"--checkpoint-dir={checkpoint_dir}",
     ]
     if checkpoint_file:
@@ -160,7 +164,7 @@ def evaluate_op(
         config (str): Path to estimator config file.
         checkpoint_file (str): Path to an estimator checkpoint file.
         test_data (str): Path to test dataset directory.
-        tb_log_dir (str): Path to tensorbload log directory.
+        tb_log_dir (str): Path to tensorboard log directory.
         checkpoint_dir (str): Path to checkpoint file directory.
         volume (kfp.dsl.PipelineVolume): The volume where datasets are stored.
         memory_limit (str): Set memory limit for this operator. For simplicity,

--- a/tests/test_kfp_output.py
+++ b/tests/test_kfp_output.py
@@ -24,7 +24,7 @@ def test_serialize_and_write_metrics():
             ]
         }
         writer_obj = KubeflowPipelineWriter(
-            filename=file_name, filepath=file_path
+            kfp_metrics_filename=file_name, kfp_log_dir=file_path
         )
         writer_obj.add_metric(name="mAR", val=0.787)
         writer_obj.add_metric(name="mAP", val=0.667)


### PR DESCRIPTION
# Peer Review Information

- KFPWriter class now performs all actions relation to kubeflow pipeline or dashboard such as writing metrics artifacts and visualizer json file for tensorboard.
- Pytorch tensorboard summarywriter will only write files when the process is master.
- Moved summarywriter instantiation on back to `base.py`
- Updated pipeline definitions

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Please read our [contribution guide](https://github.com/Unity-Technologies/dataset-insights/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
