### PR TITLE
MLFlow: Lookup client_id and host_id from Kubernetes env variable

### DIFF
--- a/datasetinsights/io/tracker/factory.py
+++ b/datasetinsights/io/tracker/factory.py
@@ -48,23 +48,19 @@ class TrackerFactory:
             raise InvalidTrackerError
 
     @staticmethod
-    def _mlflow_tracker_instance(mlflow_config):
+    def _mlflow_tracker_instance(config):
 
         """Static instance access method.
 
         Args:
-            host_id: MlTracker server host
-            client_id: MLFlow tracking server client id
-            exp_name: name of the experiment
+            config : config object, holds server details
         Returns:
             tracker singleton instance.
         """
         if not TrackerFactory.__tracker_instance:
             with TrackerFactory.__singleton_lock:
                 if not TrackerFactory.__tracker_instance:
-                    TrackerFactory.__tracker_instance = MLFlowTracker(
-                        mlflow_config
-                    )
+                    TrackerFactory.__tracker_instance = MLFlowTracker(config)
         logger.info("getting tracker instance")
         return TrackerFactory.__tracker_instance
 

--- a/datasetinsights/io/tracker/factory.py
+++ b/datasetinsights/io/tracker/factory.py
@@ -56,7 +56,7 @@ class TrackerFactory:
             raise InvalidTrackerError
 
     @staticmethod
-    def _mlflow_tracker_instance(**kwarg):
+    def _mlflow_tracker_instance(**kwargs):
 
         """Static instance access method.
 
@@ -68,7 +68,7 @@ class TrackerFactory:
         if not TrackerFactory.__tracker_instance:
             with TrackerFactory.__singleton_lock:
                 if not TrackerFactory.__tracker_instance:
-                    TrackerFactory.__tracker_instance = MLFlowTracker(**kwarg)
+                    TrackerFactory.__tracker_instance = MLFlowTracker(**kwargs)
         logger.info("getting tracker instance")
         return TrackerFactory.__tracker_instance
 

--- a/datasetinsights/io/tracker/factory.py
+++ b/datasetinsights/io/tracker/factory.py
@@ -69,7 +69,7 @@ class TrackerFactory:
         """Static instance access method.
 
         Args:
-            kwarg : key-value pairs of mlflow parameters
+            kwargs : key-value pairs of mlflow parameters
         Returns:
             tracker singleton instance.
         """

--- a/datasetinsights/io/tracker/factory.py
+++ b/datasetinsights/io/tracker/factory.py
@@ -31,9 +31,17 @@ class TrackerFactory:
         if TrackerFactory.MLFLOW_TRACKER == tracker_type:
 
             try:
-                mlf_tracker = TrackerFactory._mlflow_tracker_instance(
-                    config
-                ).get_mlflow()
+                tracker = config.get(TrackerFactory.TRACKER, None)
+                if tracker and tracker.get(TrackerFactory.MLFLOW_TRACKER, None):
+                    mlflow_config = tracker.get(TrackerFactory.MLFLOW_TRACKER)
+
+                    mlf_tracker = TrackerFactory._mlflow_tracker_instance(
+                        **mlflow_config
+                    ).get_mlflow()
+                else:
+                    mlf_tracker = (
+                        TrackerFactory._mlflow_tracker_instance().get_mlflow()
+                    )
                 logger.info("initializing mlflow_tracker")
                 return mlf_tracker
             except Exception as e:
@@ -48,19 +56,19 @@ class TrackerFactory:
             raise InvalidTrackerError
 
     @staticmethod
-    def _mlflow_tracker_instance(config):
+    def _mlflow_tracker_instance(**kwarg):
 
         """Static instance access method.
 
         Args:
-            config : config object, holds server details
+            kwarg : key-value pairs of mlflow parameters
         Returns:
             tracker singleton instance.
         """
         if not TrackerFactory.__tracker_instance:
             with TrackerFactory.__singleton_lock:
                 if not TrackerFactory.__tracker_instance:
-                    TrackerFactory.__tracker_instance = MLFlowTracker(config)
+                    TrackerFactory.__tracker_instance = MLFlowTracker(**kwarg)
         logger.info("getting tracker instance")
         return TrackerFactory.__tracker_instance
 

--- a/datasetinsights/io/tracker/factory.py
+++ b/datasetinsights/io/tracker/factory.py
@@ -1,6 +1,8 @@
 import logging
 import threading
 
+from mlflow.exceptions import MlflowException
+
 from datasetinsights.io.exceptions import InvalidTrackerError
 from datasetinsights.io.tracker.mlflow import MLFlowTracker
 
@@ -44,9 +46,15 @@ class TrackerFactory:
                     )
                 logger.info("initializing mlflow_tracker")
                 return mlf_tracker
+            except ValueError as e:
+                logger.warning(
+                    "failed mlflow initialization, " "Host is not configured", e
+                )
+            except MlflowException as e:
+                logger.warning("failed mlflow initialization,", e)
             except Exception as e:
                 logger.warning(
-                    "failed mlflow initialization, " "starting null_tracker", e,
+                    "failed mlflow initialization, " "starting null_tracker", e
                 )
 
             logger.info("initializing null_tracker")

--- a/datasetinsights/io/tracker/factory.py
+++ b/datasetinsights/io/tracker/factory.py
@@ -11,12 +11,11 @@ class TrackerFactory:
     """Factory: responsible for creating and holding singleton instance
         of tracker classes"""
 
-    TRACKER = "tracker"
-    HOST_ID = "host"
     MLFLOW_TRACKER = "mlflow"
     __singleton_lock = threading.Lock()
     __tracker_instance = None
     RUN_FAILED = "FAILED"
+    TRACKER = "tracker"
 
     @staticmethod
     def create(config=None, tracker_type=None):
@@ -31,22 +30,16 @@ class TrackerFactory:
         """
         if TrackerFactory.MLFLOW_TRACKER == tracker_type:
 
-            tracker = config.get(TrackerFactory.TRACKER, None)
-            if tracker and tracker.get(TrackerFactory.MLFLOW_TRACKER, None):
-                mlflow_config = tracker.get(TrackerFactory.MLFLOW_TRACKER)
-                if mlflow_config.get(TrackerFactory.HOST_ID, None):
-                    try:
-                        mlf_tracker = TrackerFactory._mlflow_tracker_instance(
-                            mlflow_config
-                        ).get_mlflow()
-                        logger.info("initializing mlflow_tracker")
-                        return mlf_tracker
-                    except Exception as e:
-                        logger.warning(
-                            "failed mlflow initialization, "
-                            "starting null_tracker",
-                            e,
-                        )
+            try:
+                mlf_tracker = TrackerFactory._mlflow_tracker_instance(
+                    config
+                ).get_mlflow()
+                logger.info("initializing mlflow_tracker")
+                return mlf_tracker
+            except Exception as e:
+                logger.warning(
+                    "failed mlflow initialization, " "starting null_tracker", e,
+                )
 
             logger.info("initializing null_tracker")
             return TrackerFactory._null_tracker()

--- a/datasetinsights/io/tracker/mlflow.py
+++ b/datasetinsights/io/tracker/mlflow.py
@@ -64,10 +64,11 @@ class MLFlowTracker:
             run(str, optional): MLFlow tracking run name
             experiment(str, optional): MLFlow tracking experiment name
         """
-        client_id, host_id = MLFlowTracker._get_variables(
-            client_id=client_id, host_id=host
+        host_id = MLFlowTracker._get_host_id(host)
+        client_id = MLFlowTracker._get_client_id(client_id)
+        logger.info(
+            f"client_id:{client_id} and host_id:{host_id} connecting to mlflow"
         )
-
         if client_id:
             _refresh_token(client_id)
             thread = RefreshTokenThread(client_id)
@@ -90,26 +91,20 @@ class MLFlowTracker:
         return self.__mlflow
 
     @staticmethod
-    def _get_variables(client_id=None, host_id=None):
-        """Initializes mlflow variables. if `host_id` and `client_id`
+    def _get_host_id(host_id):
+        """Initializes mlflow variables. if `host_id`
             not passed through YAML config then retrieve value from
             env variable.
 
         Args:
-            client_id(str, optional): MLFlow tracking server client id
             host_id(str, optional): MLFlow tracking server host id
         Returns:
-            client_id(str, optional): MLFlow tracking server client id
             host_id(str, required): MLFlow tracking server host id
         Raises:
             ValueError: If `host_id` is not available in both YAML config
             and env variable.
         """
-        if not client_id:
-            client_id = os.environ.get("MLFLOW_CLIENT_ID", None)
-            logger.debug(
-                f"client_id:{client_id} from " f"kubernetes env variable"
-            )
+
         if not host_id:
             if not os.environ.get("MLFLOW_HOST_ID", None):
                 logger.warning(f"host_id not found")
@@ -117,13 +112,26 @@ class MLFlowTracker:
             host_id = os.environ.get("MLFLOW_HOST_ID", None)
             logger.debug(f"host_id: {host_id} from " f"kubernetes env variable")
 
-        logger.info(
-            f"client_id:{client_id} and host_id:{host_id} connecting to mlflow"
-        )
-        return (
-            client_id,
-            host_id,
-        )
+        return host_id
+
+    @staticmethod
+    def _get_client_id(client_id):
+        """Initializes mlflow variables. if `client_id`
+            not passed through YAML config then retrieve value from
+            env variable.
+
+        Args:
+            client_id(str, optional): MLFlow tracking server client id
+        Returns:
+            client_id(str, optional): MLFlow tracking server client id
+
+        """
+        if not client_id:
+            client_id = os.environ.get("MLFLOW_CLIENT_ID", None)
+            logger.debug(
+                f"client_id:{client_id} from " f"kubernetes env variable"
+            )
+        return client_id
 
 
 class RefreshTokenThread(threading.Thread):

--- a/datasetinsights/io/tracker/mlflow.py
+++ b/datasetinsights/io/tracker/mlflow.py
@@ -13,20 +13,22 @@ logger = logging.getLogger(__name__)
 
 
 class MLFlowTracker:
-    """ MlFlow tracker class, responsible for setting host, client_id and return
+    """ MlFlow tracker class:
+        Responsible for setting host, client_id and return
         initialized mlflow. It also refreshes the access token through daemon
         thread. To start mlflow, host is required either through config YAML or
         Kubernetes secrets.
-        Case 1: Host and client_id are not configured in both YAML and
-                kubernetes env variable. Null tracker will be initiated.
-        Case 2: Host and client_id both are configured in either in YAML or
-                kubernetes variable. mlflow will initiate background thread
-                to refresh token and will start mlflow tracker.
-        Case 3: Only Host id is configured and client_id is None, either in YAML
-                or kubernetes variable. mlflow tracker will start without
-                initiating background thread.
-        Order of lookup: If host and client_id are configured in YAML then that
-                will be used else it will lookup in Kubernetes env variable.
+    Possible cases:
+        Case 1: Host and client_id are not configured:
+                Null tracker will be initiated.
+        Case 2: Host and client_id both are configured:
+                mlflow will initiate background thread to refresh token and
+                will start mlflow tracker.
+        Case 3: Only Host id is configured and client_id is None:
+                mlflow tracker will start without initiating background thread.
+    Order of lookup:
+        If host and client_id are configured in YAML then that
+        will be used else it will lookup in Kubernetes env variable.
     Examples:
          # Set MLTracking server UI, default is local file
         >>> mlflow.set_tracking_uri(TRACKING_URI)

--- a/datasetinsights/io/tracker/mlflow.py
+++ b/datasetinsights/io/tracker/mlflow.py
@@ -76,11 +76,15 @@ class MLFlowTracker:
             thread.start()
         mlflow.set_tracking_uri(host_id)
         mlflow.set_experiment(experiment_name=experiment)
-        logger.info(f"setting mlflow experiment name: {experiment}")
+        experiment_id = mlflow.get_experiment_by_name(experiment).experiment_id
+        logger.info(
+            f"Starting mlflow: experiment name: {experiment} "
+            f"and experiment id: {experiment_id}"
+        )
 
         self.__mlflow = mlflow
-        self.__mlflow.start_run(run_name=run)
-        logger.info("instantiated mlflow")
+        active_run = self.__mlflow.start_run(run_name=run)
+        logger.info(f"Instantiated mlflow: run id: {active_run.info.run_id}")
 
     def get_mlflow(self):
         """ method to access initialized mlflow

--- a/datasetinsights/io/tracker/mlflow.py
+++ b/datasetinsights/io/tracker/mlflow.py
@@ -95,17 +95,22 @@ class MLFlowTracker:
         run_name = MLFlowTracker.DEFAULT_RUN_NAME
         exp_name = MLFlowTracker.DEFAULT_EXP_NAME
         tracker = config.get(MLFlowTracker.TRACKER, None)
+        logger.debug(
+            f"client_id:{client_id} and host_id: {host_id} from "
+            f"kubernetes env variable"
+        )
         if tracker and tracker.get(MLFlowTracker.MLFLOW_TRACKER, None):
-            logger.info(f"overriding client_id and host_id")
             mlflow_config = tracker.get(MLFlowTracker.MLFLOW_TRACKER)
-            if mlflow_config.get(MLFlowTracker.HOST_ID, None):
-                host_id = mlflow_config.get(MLFlowTracker.HOST_ID)
-            if mlflow_config.get(MLFlowTracker.CLIENT_ID, None):
-                client_id = mlflow_config.get(MLFlowTracker.CLIENT_ID)
-            if mlflow_config.get(MLFlowTracker.RUN_NAME, None):
-                run_name = mlflow_config.get(MLFlowTracker.RUN_NAME)
-            if mlflow_config.get(MLFlowTracker.EXP_NAME, None):
-                exp_name = mlflow_config.get(MLFlowTracker.EXP_NAME)
+            host_id = mlflow_config.get(MLFlowTracker.HOST_ID, host_id)
+            client_id = mlflow_config.get(MLFlowTracker.CLIENT_ID, client_id)
+            run_name = mlflow_config.get(MLFlowTracker.RUN_NAME, run_name)
+            exp_name = mlflow_config.get(MLFlowTracker.EXP_NAME, exp_name)
+            logger.debug(
+                f"client_id:{client_id} and host_id:{host_id} from yaml config"
+            )
+        logger.info(
+            f"client_id:{client_id} and host_id:{host_id} connecting to mlflow"
+        )
         if not host_id:
             logger.warning(f"host_id not found")
             raise ValueError("host_id not configured")

--- a/datasetinsights/io/tracker/mlflow.py
+++ b/datasetinsights/io/tracker/mlflow.py
@@ -81,9 +81,9 @@ class MLFlowTracker:
             ValueError: If `host_id` is not available in both YAML config
             and env variable.
         """
-        host = MLFlowTracker._get_host_id(host)
+        host = host or os.environ.get("MLFLOW_HOST_ID", None)
         MLFlowTracker._validate(host)
-        client_id = MLFlowTracker._get_client_id(client_id)
+        client_id = client_id or os.environ.get("MLFLOW_CLIENT_ID", None)
         logger.info(
             f"client_id:{client_id} and host_id:{host} connecting to mlflow"
         )
@@ -111,43 +111,6 @@ class MLFlowTracker:
         """
         logger.info("get mlflow")
         return self.__mlflow
-
-    @staticmethod
-    def _get_host_id(host_id):
-        """Initializes mlflow variables. if `host_id`
-            not passed through YAML config then retrieve value from
-            env variable.
-
-        Args:
-            host_id(str, optional): MLFlow tracking server host id
-        Returns:
-            host_id(str, optional): MLFlow tracking server host id
-        """
-
-        if not host_id:
-            host_id = os.environ.get("MLFLOW_HOST_ID", None)
-            logger.debug(f"host_id: {host_id} from " f"kubernetes env variable")
-
-        return host_id
-
-    @staticmethod
-    def _get_client_id(client_id):
-        """Initializes mlflow variables. if `client_id`
-            not passed through YAML config then retrieve value from
-            env variable.
-
-        Args:
-            client_id(str, optional): MLFlow tracking server client id
-        Returns:
-            client_id(str, optional): MLFlow tracking server client id
-
-        """
-        if not client_id:
-            client_id = os.environ.get("MLFLOW_CLIENT_ID", None)
-            logger.debug(
-                f"client_id:{client_id} from " f"kubernetes env variable"
-            )
-        return client_id
 
     @staticmethod
     def _validate(host):

--- a/datasetinsights/io/tracker/mlflow.py
+++ b/datasetinsights/io/tracker/mlflow.py
@@ -59,10 +59,10 @@ class MLFlowTracker:
     ):
         """constructor.
         Args:
-            client_id : MLFlow tracking server client id
-            host : MLFlow tracking server host name
-            run : MLFlow tracking run name
-            experiment : MLFlow tracking experiment name
+            client_id(str, optional): MLFlow tracking server client id
+            host(str, optional): MLFlow tracking server host name
+            run(str, optional): MLFlow tracking run name
+            experiment(str, optional): MLFlow tracking experiment name
         """
         client_id, host_id = MLFlowTracker._get_variables(
             client_id=client_id, host_id=host
@@ -91,13 +91,19 @@ class MLFlowTracker:
 
     @staticmethod
     def _get_variables(client_id=None, host_id=None):
-        """initialize mlflow variables.
+        """Initializes mlflow variables. if `host_id` and `client_id`
+            not passed through YAML config then retrieve value from
+            env variable.
+
         Args:
-            client_id : MLFlow tracking server client id
-            host_id : MLFlow tracking server host id
+            client_id(str, optional): MLFlow tracking server client id
+            host_id(str, optional): MLFlow tracking server host id
         Returns:
-            client_id: MLFlow tracking server client id
-            host_id: MLFlow tracking server host id
+            client_id(str, optional): MLFlow tracking server client id
+            host_id(str, required): MLFlow tracking server host id
+        Raises:
+            ValueError: If `host_id` is not available in both YAML config
+            and env variable.
         """
         if not client_id:
             client_id = os.environ.get("MLFLOW_CLIENT_ID", None)

--- a/kubeflow/compiled/evaluate_the_model.yaml
+++ b/kubeflow/compiled/evaluate_the_model.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: evaluate-the-model-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:55.837308',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2021-01-04T15:53:39.220225',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Evaluate the model", "inputs":
       [{"default": "unitytechnologies/datasetinsights:latest", "name": "docker", "optional":
       true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -47,6 +47,12 @@ spec:
         --kfp-ui-metadata-filename=kfp_ui_metadata.json, --kfp-metrics-filename=kfp_metrics.json]
       command: [datasetinsights, evaluate]
       env:
+      - name: MLFLOW_HOST_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_HOST_ID}
+      - name: MLFLOW_CLIENT_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_CLIENT_ID}
       - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /secret/gcp-credentials/user-gcp-sa.json}
       - {name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, value: /secret/gcp-credentials/user-gcp-sa.json}
       image: '{{inputs.parameters.docker}}'

--- a/kubeflow/compiled/train_on_real_world_dataset.yaml
+++ b/kubeflow/compiled/train_on_real_world_dataset.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-real-world-dataset-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:53.753331',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2021-01-04T15:53:36.873123',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on real world dataset",
       "inputs": [{"default": "unitytechnologies/datasetinsights:latest", "name": "docker",
       "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -72,6 +72,12 @@ spec:
         --kfp-ui-metadata-filename=kfp_ui_metadata.json, '--checkpoint-dir={{inputs.parameters.checkpoint_dir}}']
       command: [datasetinsights, train]
       env:
+      - name: MLFLOW_HOST_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_HOST_ID}
+      - name: MLFLOW_CLIENT_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_CLIENT_ID}
       - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /secret/gcp-credentials/user-gcp-sa.json}
       - {name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, value: /secret/gcp-credentials/user-gcp-sa.json}
       image: '{{inputs.parameters.docker}}'

--- a/kubeflow/compiled/train_on_synthdet_sample.yaml
+++ b/kubeflow/compiled/train_on_synthdet_sample.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-the-synthdet-sample-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:52.999713',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2021-01-04T15:53:36.094994',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on the SynthDet
       sample", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/synthetic/SynthDet.zip",
@@ -73,6 +73,12 @@ spec:
       command: [python, -m, torch.distributed.launch, --nproc_per_node=8, --use_env,
         datasetinsights, train]
       env:
+      - name: MLFLOW_HOST_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_HOST_ID}
+      - name: MLFLOW_CLIENT_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_CLIENT_ID}
       - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /secret/gcp-credentials/user-gcp-sa.json}
       - {name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, value: /secret/gcp-credentials/user-gcp-sa.json}
       image: '{{inputs.parameters.docker}}'

--- a/kubeflow/compiled/train_on_synthetic_and_real_dataset.yaml
+++ b/kubeflow/compiled/train_on_synthetic_and_real_dataset.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-synthetic-real-world-dataset-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:54.469730',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2021-01-04T15:53:37.650746',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on Synthetic + Real
       World Dataset", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "https://storage.googleapis.com/datasetinsights/data/groceries/v3.zip",
@@ -75,6 +75,12 @@ spec:
         '--checkpoint-file={{inputs.parameters.checkpoint_file}}']
       command: [datasetinsights, train]
       env:
+      - name: MLFLOW_HOST_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_HOST_ID}
+      - name: MLFLOW_CLIENT_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_CLIENT_ID}
       - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /secret/gcp-credentials/user-gcp-sa.json}
       - {name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, value: /secret/gcp-credentials/user-gcp-sa.json}
       image: '{{inputs.parameters.docker}}'

--- a/kubeflow/compiled/train_on_synthetic_dataset_unity_simulation.yaml
+++ b/kubeflow/compiled/train_on_synthetic_dataset_unity_simulation.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: train-on-synthetic-dataset-unity-simulation-
-  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2020-11-04T17:16:55.152591',
+  annotations: {pipelines.kubeflow.org/kfp_sdk_version: 1.0.1, pipelines.kubeflow.org/pipeline_compilation_time: '2021-01-04T15:53:38.437907',
     pipelines.kubeflow.org/pipeline_spec: '{"description": "Train on synthetic dataset
       Unity Simulation", "inputs": [{"default": "unitytechnologies/datasetinsights:latest",
       "name": "docker", "optional": true, "type": "String"}, {"default": "<unity-project-id>",
@@ -79,6 +79,12 @@ spec:
       command: [python, -m, torch.distributed.launch, --nproc_per_node=8, --use_env,
         datasetinsights, train]
       env:
+      - name: MLFLOW_HOST_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_HOST_ID}
+      - name: MLFLOW_CLIENT_ID
+        valueFrom:
+          secretKeyRef: {name: dev-mlflow-secret, key: MLFLOW_CLIENT_ID}
       - {name: GOOGLE_APPLICATION_CREDENTIALS, value: /secret/gcp-credentials/user-gcp-sa.json}
       - {name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE, value: /secret/gcp-credentials/user-gcp-sa.json}
       image: '{{inputs.parameters.docker}}'

--- a/kubeflow/pipelines.py
+++ b/kubeflow/pipelines.py
@@ -8,6 +8,19 @@ KFP_LOG_DIR = "/kfp_logs"
 KFP_UI_METADATA_FILENAME = "kfp_ui_metadata.json"
 KFP_METRICS_FILENAME = "kfp_metrics.json"
 
+mlflow_host_env = {
+    "name": "MLFLOW_HOST_ID",
+    "valueFrom": {
+        "secretKeyRef": {"name": "dev-mlflow-secret", "key": "MLFLOW_HOST_ID"}
+    },
+}
+mlflow_client_env = {
+    "name": "MLFLOW_CLIENT_ID",
+    "valueFrom": {
+        "secretKeyRef": {"name": "dev-mlflow-secret", "key": "MLFLOW_CLIENT_ID"}
+    },
+}
+
 
 def volume_op(*, volume_size):
     """ Create Kubernetes persistant volume to store data.
@@ -134,6 +147,7 @@ def train_op(
         command=command,
         arguments=arguments,
         pvolumes={DATA_PATH: volume},
+        container_kwargs={"env": [mlflow_host_env, mlflow_client_env]},
         file_outputs={
             "mlpipeline-ui-metadata": os.path.join(
                 KFP_LOG_DIR, KFP_UI_METADATA_FILENAME
@@ -198,6 +212,7 @@ def evaluate_op(
             f"--kfp-ui-metadata-filename={KFP_UI_METADATA_FILENAME}",
             f"--kfp-metrics-filename={KFP_METRICS_FILENAME}",
         ],
+        container_kwargs={"env": [mlflow_host_env, mlflow_client_env]},
         file_outputs={
             "mlpipeline-metrics": os.path.join(
                 KFP_LOG_DIR, KFP_METRICS_FILENAME

--- a/tests/configs/faster_rcnn_groceries_real_test.yaml
+++ b/tests/configs/faster_rcnn_groceries_real_test.yaml
@@ -47,6 +47,6 @@ val_interval: 1
 tracker:
   mlflow:
     experiment: datasetinsights
-    run:
-    client_id:
-    host:
+    run: test
+    client_id: test
+    host: test

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -35,12 +35,11 @@ def test_refresh_token(mock_id_token):
     mock_id_token.assert_called_once()
 
 
-@patch("datasetinsights.io.tracker.mlflow.MLFlowTracker")
+@patch("datasetinsights.io.tracker.factory.MLFlowTracker")
 def test_get_mltracker_instance(mock_tracker, config):
-    mlflow_config = config["tracker"].get(TrackerFactory.MLFLOW_TRACKER)
     tf = TrackerFactory()
-    instance1 = tf._mlflow_tracker_instance(mlflow_config)
-    instance2 = tf._mlflow_tracker_instance(mlflow_config)
+    instance1 = tf._mlflow_tracker_instance(config)
+    instance2 = tf._mlflow_tracker_instance(config)
     assert instance1 == instance2
 
 
@@ -59,22 +58,20 @@ def test_get_nulltracker_instance(mock_tracker):
 def test_factory_create_mltracker(mock_get_tracker, config):
     mock_mlflow = MagicMock()
     mock_get_tracker.return_value = mock_mlflow
-    mlflow_config = config["tracker"].get(TrackerFactory.MLFLOW_TRACKER)
-    config.tracker.mlflow.client_id = CLIENT_ID
-    config.tracker.mlflow.host = HOST_ID
-    config.tracker.mlflow.experiment = EXP_NAME
     TrackerFactory.create(config, TrackerFactory.MLFLOW_TRACKER)
-    mock_get_tracker.assert_called_with(mlflow_config)
+    mock_get_tracker.assert_called_with(config)
     mock_mlflow.get_mlflow.assert_called_once()
 
 
+@patch(
+    "datasetinsights.io.tracker.factory.TrackerFactory."
+    "_mlflow_tracker_instance"
+)
 @patch("datasetinsights.io.tracker.factory.TrackerFactory._null_tracker")
-def test_factory_create_nulltracker(mock_get_tracker, config):
-    config.tracker.mlflow.client_id = None
-    config.tracker.mlflow.host = None
-    config.tracker.mlflow.experiment = None
-    TrackerFactory.create(config, TrackerFactory.MLFLOW_TRACKER)
-    mock_get_tracker.assert_called_once()
+def test_factory_create_nulltracker(mock_get_tracker, mock_instance, config):
+    with pytest.raises(Exception):
+        TrackerFactory.create(config, TrackerFactory.MLFLOW_TRACKER)
+        mock_get_tracker.assert_called_once()
 
 
 @patch("datasetinsights.io.tracker.factory.NullTracker._stdout_handler")
@@ -91,8 +88,7 @@ def test_mLflow_tracker(mock_refresh, mock_mlflow, mock_thread_start, config):
     config.tracker.mlflow.client_id = CLIENT_ID
     config.tracker.mlflow.host = HOST_ID
     config.tracker.mlflow.experiment = EXP_NAME
-    mlflow_config = config["tracker"].get(TrackerFactory.MLFLOW_TRACKER)
-    MLFlowTracker(mlflow_config)
+    MLFlowTracker(config)
     mock_thread_start.assert_called_once()
     mock_refresh.assert_called_once()
     mock_mlflow.set_tracking_uri.assert_called_with(HOST_ID)
@@ -113,8 +109,16 @@ def test_mLflow_tracker_run(mock_refresh, mock_mlflow, mock_thread_run, config):
     config.tracker.mlflow.client_id = CLIENT_ID
     config.tracker.mlflow.host = HOST_ID
     config.tracker.mlflow.experiment = EXP_NAME
-    mlflow_config = config["tracker"].get(TrackerFactory.MLFLOW_TRACKER)
-    MLFlowTracker(mlflow_config)
+    MLFlowTracker(config)
     mock_thread_run.assert_called_once()
     mock_refresh.assert_called_once()
     mock_mlflow.set_tracking_uri.assert_called_with(HOST_ID)
+
+
+def test_get_variables(config):
+    config.tracker.mlflow.client_id = CLIENT_ID
+    config.tracker.mlflow.host = HOST_ID
+    config.tracker.mlflow.experiment = EXP_NAME
+    config.tracker.mlflow.run = RUN_NAME
+    return_val = MLFlowTracker._get_variables(config)
+    assert (CLIENT_ID, HOST_ID, RUN_NAME, EXP_NAME) == return_val

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -111,16 +111,6 @@ def test_mlflow_tracker_run(mock_refresh, mock_mlflow, mock_thread_run):
     mock_mlflow.set_tracking_uri.assert_called_with(HOST_ID)
 
 
-def test_get_host_id():
-    return_val = MLFlowTracker._get_host_id(HOST_ID)
-    assert HOST_ID == return_val
-
-
-def test_get_client_id():
-    return_val = MLFlowTracker._get_client_id(CLIENT_ID)
-    assert CLIENT_ID == return_val
-
-
 def test_none_host_id():
     with pytest.raises(ValueError):
         MLFlowTracker._validate(None)

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -111,13 +111,16 @@ def test_mlflow_tracker_run(mock_refresh, mock_mlflow, mock_thread_run):
     mock_mlflow.set_tracking_uri.assert_called_with(HOST_ID)
 
 
-def test_get_variables():
-    return_val = MLFlowTracker._get_variables(
-        client_id=CLIENT_ID, host_id=HOST_ID
-    )
-    assert (CLIENT_ID, HOST_ID) == return_val
+def test_get_host_id():
+    return_val = MLFlowTracker._get_host_id(HOST_ID)
+    assert HOST_ID == return_val
+
+
+def test_get_client_id():
+    return_val = MLFlowTracker._get_client_id(CLIENT_ID)
+    assert CLIENT_ID == return_val
 
 
 def test_none_host_id():
     with pytest.raises(ValueError):
-        MLFlowTracker._get_variables(client_id=None, host_id=None)
+        MLFlowTracker._get_host_id(None)

--- a/tests/test_mlflow_tracker.py
+++ b/tests/test_mlflow_tracker.py
@@ -123,4 +123,4 @@ def test_get_client_id():
 
 def test_none_host_id():
     with pytest.raises(ValueError):
-        MLFlowTracker._get_host_id(None)
+        MLFlowTracker._validate(None)


### PR DESCRIPTION
# Peer Review Information
This commit includes following changes:
1. Lookup mlflow client_id and host_id from Kubernetes env variable, if both are configured in config YAML then override with YAML values.
2. Updated pipelines.py with env variable lookup, compiled pipelines
3. Unit test case

Kubeflow run_id: train_on_real_world_dataset-test 5
# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Please read our [contribution guide](https://github.com/Unity-Technologies/dataset-insights/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.