### PR TITLE
Fixed cryptography rust dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update \
     && ln -s /usr/bin/python3.7 /usr/local/bin/python
 
 # Pin setuptools to 49.x.x until this [issue](https://github.com/pypa/setuptools/issues/2350) is fixed.
-RUN python -m pip install --upgrade pip poetry==1.0.10 setuptools==49.6.0
+RUN python -m pip install --upgrade pip poetry==1.0.10 setuptools==49.6.0 -U pip cryptography==3.3.2
+# pin cryptography to 3.3.2 until this (https://github.com/Azure/azure-cli/issues/16858) is fixed.
 
 # Add Tini
 ENV TINI_VERSION v0.18.0


### PR DESCRIPTION
# Peer Review Information
Issue: Docker build was failing because of newly introduced rust dependency in cryptography.
https://github.com/Unity-Technologies/datasetinsights/runs/1966203805?check_suite_focus=true

- Fixed cryptography rust dependency by pinning at 3.3.2
- reference: https://github.com/Azure/azure-cli/issues/16858

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Please read our [contribution guide](https://github.com/Unity-Technologies/dataset-insights/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.