### PR TITLE
Remove latest tag to stop override from 0.2.x

### DIFF
--- a/.github/workflows/publish-docker-hub.yaml
+++ b/.github/workflows/publish-docker-hub.yaml
@@ -15,5 +15,4 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           repository: unitytechnologies/datasetinsights
-          tags: latest
           tag_with_ref: true


### PR DESCRIPTION
# Peer Review Information

- Removed latest tag to stop creating docker image with latest tag from 0.2.x branch.
Requirement: https://github.com/Unity-Technologies/datasetinsights/issues/143

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Please read our [contribution guide](https://github.com/Unity-Technologies/dataset-insights/blob/master/CONTRIBUTING.md)
at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.