### PR TITLE
Add New metrics in Notebook

### DIFF
--- a/notebooks/Perception_Statistics.ipynb
+++ b/notebooks/Perception_Statistics.ipynb
@@ -111,13 +111,12 @@
    "outputs": [],
    "source": [
     "from datasetinsights.stats.statistics import RenderedObjectInfo\n",
-    "import datasetinsights.datasets.unity_perception.metrics as metrics\n",
     "from datasetinsights.datasets.unity_perception.exceptions import DefinitionIDError\n",
     "from datasetinsights.stats import bar_plot, histogram_plot, rotation_plot\n",
     "\n",
     "max_samples = 10000          # maximum number of samples points used in histogram plots\n",
     "\n",
-    "rendered_object_info_definition_id = \"5ba92024-b3b7-41a7-9d3f-c03a6a8ddd01\"\n",
+    "rendered_object_info_definition_id = \"659c6e36-f9f8-4dd6-9651-4a80e51eabc4\"\n",
     "roinfo = None\n",
     "try:\n",
     "    roinfo = RenderedObjectInfo(data_root=data_root, def_id=rendered_object_info_definition_id)\n",
@@ -234,6 +233,539 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## SynthDet Statistics\n",
+    "Metrics specific to the simulation can be loaded using `datasetinsights.datasets.unity_perception.Metrics`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Foreground placement info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasetinsights.datasets.unity_perception import Metrics\n",
+    "import pandas as pd\n",
+    "\n",
+    "metrics = Metrics(data_root=data_root)\n",
+    "foreground_placement_info_definition_id = \"061e08cc-4428-4926-9933-a6732524b52b\"\n",
+    "\n",
+    "def read_foreground_placement_info(metrics=None, name=None, columns=None):\n",
+    "    filtered_metrics = metrics.filter_metrics(foreground_placement_info_definition_id)\n",
+    "    combined = pd.DataFrame(filtered_metrics[name].to_list(), columns=columns)\n",
+    "    \n",
+    "    return combined"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rot_columns = (\"x_rot\", \"y_rot\", \"z_rot\")\n",
+    "orientation_info = read_foreground_placement_info(metrics=metrics, name=\"rotation\", columns=rot_columns)\n",
+    "orientation_info.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rotation_plot(\n",
+    "    orientation_info,\n",
+    "    x=\"x_rot\",\n",
+    "    y=\"y_rot\",\n",
+    "    z=\"z_rot\",\n",
+    "    title=\"Object orientations\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    orientation_info, \n",
+    "    x=\"x_rot\",  \n",
+    "    x_title=\"Object Rotation (Degree)\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Object Rotations along X direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    orientation_info, \n",
+    "    x=\"y_rot\",  \n",
+    "    x_title=\"Object Rotation (Degree)\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Object Rotations along Y direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    orientation_info, \n",
+    "    x=\"z_rot\",  \n",
+    "    x_title=\"Object Rotation (Degree)\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Object Rotations along Z direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Foreground Scale Info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scale_columns = (\"x_scale\", \"y_scale\", \"z_scale\")\n",
+    "scale_info = read_foreground_placement_info(metrics=metrics, name=\"scale\", columns=scale_columns)\n",
+    "scale_info.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    scale_info, \n",
+    "    x=\"x_scale\",  \n",
+    "    x_title=\"Scale\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Foreground Scale along X direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    scale_info, \n",
+    "    x=\"y_scale\",  \n",
+    "    x_title=\"Scale\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Foreground Scale along Y direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    scale_info, \n",
+    "    x=\"z_scale\",  \n",
+    "    x_title=\"Scale\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Foreground Object Scale along Z direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Foreground Position Info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pos_columns = (\"x_pos\", \"y_pos\", \"z_pos\")\n",
+    "pos_info = read_foreground_placement_info(metrics=metrics, name=\"position\", columns=pos_columns)\n",
+    "pos_info.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    pos_info, \n",
+    "    x=\"x_pos\",\n",
+    "    x_title=\"Position\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Foreground Position along X direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    pos_info, \n",
+    "    x=\"y_pos\",\n",
+    "    x_title=\"Position\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Foreground Position along Y direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    pos_info, \n",
+    "    x=\"z_pos\",\n",
+    "    x_title=\"Position\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Foreground Position along Z direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lighting info "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lighting_info_definition_id = \"939248ee-668a-4e98-8e79-e7909f034a47\"\n",
+    "x_y_columns = [\"x_rotation\", \"y_rotation\"]\n",
+    "color_columns = [\"color.r\", \"color.g\", \"color.b\", \"color.a\"]\n",
+    "other_columns = [\"intensity\", \"enabled\"]\n",
+    "\n",
+    "def read_lighting_info(metrics):\n",
+    "    filtered_metrics = metrics.filter_metrics(lighting_info_definition_id)\n",
+    "    colors = pd.json_normalize(filtered_metrics[\"color\"])\n",
+    "    colors.columns = color_columns\n",
+    "    combined = pd.concat([filtered_metrics[x_y_columns], colors, filtered_metrics[other_columns]], axis=1, join='inner')\n",
+    "\n",
+    "    return combined"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lighting_info = read_lighting_info(metrics)\n",
+    "lighting_info.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rotation_plot(\n",
+    "    lighting_info,\n",
+    "    x=\"x_rotation\",\n",
+    "    y=\"y_rotation\",\n",
+    "    title=\"Light orientations\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    lighting_info, \n",
+    "    x=\"x_rotation\",  \n",
+    "    x_title=\"Lighting Rotation (Degree)\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Lighting Rotations along X direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    lighting_info, \n",
+    "    x=\"y_rotation\",  \n",
+    "    x_title=\"Lighting Rotation (Degree)\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Lighting Rotations along Y direction\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    lighting_info, \n",
+    "    x=\"color.r\",  \n",
+    "    x_title=\"Lighting Color\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Lighting Color Redness\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    lighting_info, \n",
+    "    x=\"color.g\",  \n",
+    "    x_title=\"Lighting Color\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Lighting Color Greeness\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    lighting_info, \n",
+    "    x=\"color.b\",  \n",
+    "    x_title=\"Lighting Color\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Lighting Color Blueness\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    lighting_info, \n",
+    "    x=\"intensity\",  \n",
+    "    x_title=\"Lighting Intensity\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Lighting Intensity\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    lighting_info, \n",
+    "    x=\"enabled\",  \n",
+    "    x_title=\"Lighting Enabled States (Bool)\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Lighting Enabled States\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Camera Info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lighting_info_definition_id = \"a4b2253c-0eb2-4a90-9b20-6e77f1d13286\"\n",
+    "camear_columns = [\"saturation\", \"contrast\", \"vignetteIntensity\", \"gaussianDofStart\", \"gaussianDofEnd\", \"gaussianDofRadius\"]\n",
+    "\n",
+    "def read_camera_info(metrics):\n",
+    "    filtered_metrics = metrics.filter_metrics(lighting_info_definition_id)\n",
+    "\n",
+    "    return filtered_metrics[camear_columns]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "camera_info = read_camera_info(metrics)\n",
+    "camera_info.head(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    camera_info, \n",
+    "    x=\"saturation\",  \n",
+    "    x_title=\"Camera Saturation\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Camera Saturation\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    camera_info, \n",
+    "    x=\"contrast\",  \n",
+    "    x_title=\"Camera Contrast\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Camera Contrast\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    camera_info, \n",
+    "    x=\"vignetteIntensity\",  \n",
+    "    x_title=\"Camera Vignette Intensity\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Camera Vignette Intensity\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    camera_info, \n",
+    "    x=\"gaussianDofStart\",  \n",
+    "    x_title=\"Camera Gaussian Depth of Field Start\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Camera Gaussian Depth of Field Start\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    camera_info, \n",
+    "    x=\"gaussianDofEnd\",  \n",
+    "    x_title=\"Camera Gaussian Depth of Field End\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Camera Gaussian Depth of Field End\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "histogram_plot(\n",
+    "    camera_info, \n",
+    "    x=\"gaussianDofRadius\",  \n",
+    "    x_title=\"Camera Gaussian Depth of Field Radius\",\n",
+    "    y_title=\"Frequency\",\n",
+    "    title=\"Distribution of Camera Gaussian Depth of Field Radius\",\n",
+    "    max_samples=max_samples\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Annotation Visualization\n",
     "In the following sections we show how to load annotations from the Captures object and visualize them. Similar code can be used to consume annotations for model training or visualize and train on custom annotations."
    ]
@@ -295,7 +827,7 @@
     "from datasetinsights.stats.visualization.plots import plot_bboxes\n",
     "from datasetinsights.datasets.synthetic import SynDetection2D,read_bounding_box_2d\n",
     "\n",
-    "bounding_box_definition_id = \"f9f22e05-443f-4602-a422-ebe4ea9b55cb\"\n",
+    "bounding_box_definition_id = \"c31620e3-55ff-4af6-ae86-884aa0daa9b2\"\n",
     "dataset = SynDetection2D(data_path=data_root, def_id=bounding_box_definition_id)\n",
     "def draw_bounding_boxes(index):\n",
     "    image, bboxes = dataset[index]\n",
@@ -466,7 +998,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/Perception_Statistics.ipynb
+++ b/notebooks/Perception_Statistics.ipynb
@@ -233,7 +233,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## SynthDet Statistics\n",
+    "## Dataset Statistics\n",
     "Metrics specific to the simulation can be loaded using `datasetinsights.datasets.unity_perception.Metrics`. "
    ]
   },


### PR DESCRIPTION
# Peer Review Information

Add the following new metrics in `Perception_Statistics` Notebook:
- Foreground placement
- Foreground scale
- Foreground positions
- Lighting (color, pos, intensity, enabled states)
- Camera info (saturation, contrast, vignette amount, depth of field start/end/radius)
